### PR TITLE
Remove requirement matplotlib<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'numpy>=1.7.0',
         'scipy>=0.13',
         'pandas>=0.17.0',
-        'matplotlib>=1.2.0,<2',
+        'matplotlib>=1.2.0',
         'statsmodels>=0.6.1',
         'minepy>=1.2'],
     entry_points='''


### PR DESCRIPTION
In `setup.py`, mictools is set up to require matplotlib version smaller than 2. This is already a bit old version of matplotlib and as far as I see, there is no reason for this requirement. This PR removes it.